### PR TITLE
Depend on perl v5.8 not v5.800

### DIFF
--- a/META.json
+++ b/META.json
@@ -45,7 +45,7 @@
             "List::Priority" : "0",
             "Moo" : "0",
             "Tree::DAG_Node" : "0",
-            "perl" : "5.8"
+            "perl" : "v5.8"
          }
       },
       "test" : {


### PR DESCRIPTION
Perl versions are weird - http://blogs.perl.org/users/grinnz/2018/04/a-guide-to-versions-in-perl.html

5.8 actually means v5.800. Either write v5.8 or 5.8.0 to actually depend on the right version.

$ perl -E 'say version->parse($_)->normal for qw/5.8 5.8.0 v5.8/'
v5.800.0
v5.8.0
v5.8.0